### PR TITLE
Extend API: Allow generated name to be queried and deleted by ID

### DIFF
--- a/src/Controllers/AdminController.cs
+++ b/src/Controllers/AdminController.cs
@@ -218,17 +218,19 @@ namespace AzureNamingTool.Controllers
             }
         }
 
+        // GET api/<AdminController>/GetGeneratedName/5
         /// <summary>
         /// This function will return the generated names data by ID.
         /// </summary>
-        /// <returns>json - Current generated names data by ID</returns>
+        /// <param name="id">int - Generated Name id</param>
+        /// <returns>json - Current generated name data by ID</returns>
         [HttpGet]
         [Route("[action]/{id}")]
         public async Task<IActionResult> GetGeneratedName(int id)
         {
             try
             {
-                serviceResponse = await GeneratedNamesService.GetItem(id: id);
+                serviceResponse = await GeneratedNamesService.GetItem(id);
                 if (serviceResponse.Success)
                 {
                     return Ok(serviceResponse.ResponseObject);

--- a/src/Controllers/AdminController.cs
+++ b/src/Controllers/AdminController.cs
@@ -218,7 +218,7 @@ namespace AzureNamingTool.Controllers
             }
         }
 
-        // GET api/<AdminController>/GeneratedName/5
+        // GET api/<AdminController>/GetGeneratedName/5
         /// <summary>
         /// This function will return the generated names data by ID.
         /// </summary>
@@ -226,7 +226,7 @@ namespace AzureNamingTool.Controllers
         /// <returns>json - Current generated name data by ID</returns>
         [HttpGet]
         [Route("[action]/{id}")]
-        public async Task<IActionResult> GeneratedName(int id)
+        public async Task<IActionResult> GetGeneratedName(int id)
         {
             try
             {
@@ -247,7 +247,7 @@ namespace AzureNamingTool.Controllers
             }
         }
 
-        // DELETE api/<AdminController>/GeneratedName/5
+        // DELETE api/<AdminController>/DeleteGeneratedName/5
         /// <summary>
         /// This function will delete the generated names data by ID.
         /// </summary>
@@ -255,7 +255,7 @@ namespace AzureNamingTool.Controllers
         /// <returns>bool - PASS/FAIL</returns>
         [HttpDelete]
         [Route("[action]/{id}")]
-        public async Task<IActionResult> GeneratedName(int id)
+        public async Task<IActionResult> DeleteGeneratedName(int id)
         {
             try
             {

--- a/src/Controllers/AdminController.cs
+++ b/src/Controllers/AdminController.cs
@@ -218,7 +218,7 @@ namespace AzureNamingTool.Controllers
             }
         }
 
-        // GET api/<AdminController>/GetGeneratedName/5
+        // GET api/<AdminController>/GeneratedName/5
         /// <summary>
         /// This function will return the generated names data by ID.
         /// </summary>
@@ -226,11 +226,40 @@ namespace AzureNamingTool.Controllers
         /// <returns>json - Current generated name data by ID</returns>
         [HttpGet]
         [Route("[action]/{id}")]
-        public async Task<IActionResult> GetGeneratedName(int id)
+        public async Task<IActionResult> GeneratedName(int id)
         {
             try
             {
                 serviceResponse = await GeneratedNamesService.GetItem(id);
+                if (serviceResponse.Success)
+                {
+                    return Ok(serviceResponse.ResponseObject);
+                }
+                else
+                {
+                    return BadRequest(serviceResponse.ResponseObject);
+                }
+            }
+            catch (Exception ex)
+            {
+                AdminLogService.PostItem(new AdminLogMessage() { Title = "ERROR", Message = ex.Message });
+                return BadRequest(ex);
+            }
+        }
+
+        // DELETE api/<AdminController>/GeneratedName/5
+        /// <summary>
+        /// This function will delete the generated names data by ID.
+        /// </summary>
+        /// <param name="id">int - Generated Name id</param>
+        /// <returns>bool - PASS/FAIL</returns>
+        [HttpDelete]
+        [Route("[action]/{id}")]
+        public async Task<IActionResult> GeneratedName(int id)
+        {
+            try
+            {
+                serviceResponse = await GeneratedNamesService.DeleteItem(id);
                 if (serviceResponse.Success)
                 {
                     return Ok(serviceResponse.ResponseObject);

--- a/src/Controllers/AdminController.cs
+++ b/src/Controllers/AdminController.cs
@@ -219,6 +219,33 @@ namespace AzureNamingTool.Controllers
         }
 
         /// <summary>
+        /// This function will return the generated names data by ID.
+        /// </summary>
+        /// <returns>json - Current generated names data by ID</returns>
+        [HttpGet]
+        [Route("[action]/{id}")]
+        public async Task<IActionResult> GetGeneratedName(string id)
+        {
+            try
+            {
+                serviceResponse = await GeneratedNamesService.GetItem(id: int.Parse(id));
+                if (serviceResponse.Success)
+                {
+                    return Ok(serviceResponse.ResponseObject);
+                }
+                else
+                {
+                    return BadRequest(serviceResponse.ResponseObject);
+                }
+            }
+            catch (Exception ex)
+            {
+                AdminLogService.PostItem(new AdminLogMessage() { Title = "ERROR", Message = ex.Message });
+                return BadRequest(ex);
+            }
+        }
+
+        /// <summary>
         /// This function will purge the generated names data.
         /// </summary>
         /// <returns>dttring - Successful operation</returns>

--- a/src/Controllers/AdminController.cs
+++ b/src/Controllers/AdminController.cs
@@ -224,11 +224,11 @@ namespace AzureNamingTool.Controllers
         /// <returns>json - Current generated names data by ID</returns>
         [HttpGet]
         [Route("[action]/{id}")]
-        public async Task<IActionResult> GetGeneratedName(string id)
+        public async Task<IActionResult> GetGeneratedName(int id)
         {
             try
             {
-                serviceResponse = await GeneratedNamesService.GetItem(id: int.Parse(id));
+                serviceResponse = await GeneratedNamesService.GetItem(id: id);
                 if (serviceResponse.Success)
                 {
                     return Ok(serviceResponse.ResponseObject);


### PR DESCRIPTION
This will allow API users to query the generated names by providing an ID in the URL. 