### PR TITLE
Remove Azure credentials from workflow

### DIFF
--- a/.github/workflows/deploy-azure-naming-tool-to-azure-webapps-dotnet-core.yml
+++ b/.github/workflows/deploy-azure-naming-tool-to-azure-webapps-dotnet-core.yml
@@ -49,8 +49,7 @@ jobs:
           env: 
             azure-webapp-name: ${{ secrets.AZURE_WEBAPP_NAME }}
             azure-webapp-publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
-            azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          if: (env.azure-webapp-name != null && env.azure-webapp-publish-profile != null && env.azure-credentials != null)
+          if: (env.azure-webapp-name != null && env.azure-webapp-publish-profile != null)
           run: echo 'isvalid=true' >> $GITHUB_OUTPUT
             
   build:
@@ -104,11 +103,6 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: .net-app
-          
-      - name: Login to Azure
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Deploy to Azure Web App
         id: deploy-to-webapp


### PR DESCRIPTION
Azure credentials are not required when using a publish profile, as the publish profile contains credentials to authenticate to the app service publish URL already.
Removing this makes the deployment a lot easier, as [this step](https://github.com/mspnp/AzureNamingTool/wiki/Run-as-an-Azure-Web-App-Using-GitHub-Action#4-generate-azure-web-app-credentials) is no longer necessary.