### PR TITLE
New Feature - Add more site settings

### DIFF
--- a/src/Models/SiteConfiguration.cs
+++ b/src/Models/SiteConfiguration.cs
@@ -15,5 +15,8 @@
         public string? IdentityHeaderName { get; set; }
         public string? ResourceTypeEditingAllowed { get; set; } = "False";
         public string? AutoIncrementResourceInstance { get; set; } = "False";
+        public string? DisableNews { get; set; } = "False";
+        public string? DisableGeneratedNamesLog { get; set; } = "False";
+        public string? DisableInstructions { get; set; } = "False";
     }
 }

--- a/src/Pages/GeneratedNamesLog.razor
+++ b/src/Pages/GeneratedNamesLog.razor
@@ -95,8 +95,8 @@
                                             <span class="oi oi-magnifying-glass" id="addon-wrapping"></span>
                                         </span>
                                         <input class="form-control" type="search" placeholder="Filter by Created By, Generated Name, Resource Type, Components"
-                                               @bind="filterData"
-                                               @bind:event="oninput">
+                                        @bind="filterData"
+                                        @bind:event="oninput">
                                     </div>
                                 </div>
                             </div>

--- a/src/Pages/GeneratedNamesLog.razor
+++ b/src/Pages/GeneratedNamesLog.razor
@@ -95,8 +95,8 @@
                                             <span class="oi oi-magnifying-glass" id="addon-wrapping"></span>
                                         </span>
                                         <input class="form-control" type="search" placeholder="Filter by Created By, Generated Name, Resource Type, Components"
-                                        @bind="filterData"
-                                        @bind:event="oninput">
+                                               @bind="filterData"
+                                               @bind:event="oninput">
                                     </div>
                                 </div>
                             </div>
@@ -199,6 +199,7 @@
     public DateTime startdate { get; set; } = DateTime.Today.AddDays(-30);
     public DateTime enddate { get; set; } = DateTime.Today;
     private string currentuser = String.Empty;
+    private SiteConfiguration config = ConfigurationHelper.GetConfigurationData();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -207,6 +208,13 @@
         {
             var result = await session.GetAsync<bool>("admin");
             admin = (bool)result.Value;
+
+            if (Convert.ToBoolean(config.DisableGeneratedNamesLog) && !admin)
+            {
+                toastService.ShowWarning("The Generated Names Log is disabled in the site settings.");
+                NavigationManager.NavigateTo("/");
+            }
+
             await LoadData();
             duplicatenamesallowed = Convert.ToBoolean(ConfigurationHelper.GetAppSetting("DuplicateNamesAllowed"));
             StateHasChanged();

--- a/src/Pages/Index.razor
+++ b/src/Pages/Index.razor
@@ -27,10 +27,13 @@
         <p>
             The Admin page is used to configure the Azure Naming Tool. This page is only accessible by Admin users.
         </p>
-        <h4>Instructions</h4>
-        <p>
-            The Instructions page provides documentation for the site pages. Each page of the site contains a documentation link (top right) that will open contextual instructions for the current page.
-        </p>
+        @if (!Convert.ToBoolean(config.DisableInstructions) || admin)
+        {
+            <h4>Instructions</h4>
+            <p>
+                The Instructions page provides documentation for the site pages. Each page of the site contains a documentation link (top right) that will open contextual instructions for the current page.
+            </p>
+        }
         <h4>Configuration</h4>
         <p>
             The Configuration page provides all the data points that make up your naming convention.  There are 8 standard components that may be used to name each Azure resource.  The data within each of those components can be completely customized, except for the resource types.  For the resource types, only the short name, optional, and excluded values may be updated.  A delimiter may be selected to separate each component in your resource names.  However, the delimiter will be included in a resource name if that character is allowed. The tool also supports the ability to define custom components. This allows administratos to create new components for the naming convention.  Your configuration may be exported under the Global Configuration header.  We recommend doing that after defining your naming convention as a backup.  @*Lastly, use the Policy export feature to create an Azure Policy Definition.  That can be applied to your Azure environment to enforce your naming convention.*@
@@ -44,15 +47,21 @@
         <p>
             The Generate page provides a drop-down menu to select an Azure resource type. Once a resource is selected, the naming component options are provided. Read-only components cannot be changed, like the value for a resource type. Optional components, if unselected, will be null and not shown in the output. Required components do not allow a null value and will require a selection from the menu.
         </p>
-        <h4>Generated Names Log</h4>
-        <p>
-            The Generated Names Log contains a record of all names generated in the Azure Naming Tool. This includes the date, user, generated name, resource type, and components selected. This log can be exported to a .csv file.
-        </p>
-        <p>
-            <button class="btn btn-primary" title="Instructions" @onclick="@(e => OnInstructionsClick())">
-                View Instructions
-            </button>
-        </p>
+        @if (!Convert.ToBoolean(config.DisableGeneratedNamesLog) || admin)
+        {
+            <h4>Generated Names Log</h4>
+            <p>
+                The Generated Names Log contains a record of all names generated in the Azure Naming Tool. This includes the date, user, generated name, resource type, and components selected. This log can be exported to a .csv file.
+            </p>
+        }
+        @if (!Convert.ToBoolean(config.DisableInstructions) || admin)
+        {
+            <p>
+                <button class="btn btn-primary" title="Instructions" @onclick="@(e => OnInstructionsClick())">
+                    View Instructions
+                </button>
+            </p>
+        }
     </div>
 </div>
 @code {
@@ -64,6 +73,7 @@
 
     private string appversion = ConfigurationHelper.GetAssemblyVersion();
     private string updateurl = "https://github.com/mspnp/AzureNamingTool/wiki/Updating";
+    private SiteConfiguration config = ConfigurationHelper.GetConfigurationData();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/Pages/Instructions.razor
+++ b/src/Pages/Instructions.razor
@@ -34,12 +34,12 @@
                     <AdminConfigurationInstructions theme="@theme" admin="@admin" />
                 </div>
             </div>
-            <div class="card mb-3">
-                <h5 class="card-header bg-secondary text-white" id="adminlogcontainer">
+                <div class="card mb-3">
+                    <h5 class="card-header bg-secondary text-white" id="adminlogcontainer">
                     <a class="link-light text-decoration-none" data-bs-toggle="collapse" style="display:block;" href="#adminlog" role="button" aria-expanded="true" aria-controls="adminlog">
-                        <span class="oi oi-chevron-bottom" aria-hidden="true"></span> Admin Log
-                    </a>
-                </h5>
+                            <span class="oi oi-chevron-bottom" aria-hidden="true"></span> Admin Log
+                        </a>
+                    </h5>
                 <div class="card card-body collapse show @theme.ThemeStyle" id="adminlog">
                     <AdminLogInstructions theme="@theme" admin="@admin" />
                 </div>

--- a/src/Pages/Instructions.razor
+++ b/src/Pages/Instructions.razor
@@ -5,6 +5,8 @@
 @using AzureNamingTool.Shared.Instructions
 @inject StateContainer state
 @inject ProtectedSessionStorage session
+@inject IToastService toastService
+@inject NavigationManager NavigationManager
 
 <div class="card @theme!.ThemeStyle">
     <div class="card-body">
@@ -32,16 +34,16 @@
                     <AdminConfigurationInstructions theme="@theme" admin="@admin" />
                 </div>
             </div>
-                <div class="card mb-3">
-                    <h5 class="card-header bg-secondary text-white" id="adminlogcontainer">
+            <div class="card mb-3">
+                <h5 class="card-header bg-secondary text-white" id="adminlogcontainer">
                     <a class="link-light text-decoration-none" data-bs-toggle="collapse" style="display:block;" href="#adminlog" role="button" aria-expanded="true" aria-controls="adminlog">
-                            <span class="oi oi-chevron-bottom" aria-hidden="true"></span> Admin Log
-                        </a>
-                    </h5>
+                        <span class="oi oi-chevron-bottom" aria-hidden="true"></span> Admin Log
+                    </a>
+                </h5>
                 <div class="card card-body collapse show @theme.ThemeStyle" id="adminlog">
-                        <AdminLogInstructions theme="@theme" admin="@admin" />
-                    </div>
+                    <AdminLogInstructions theme="@theme" admin="@admin" />
                 </div>
+            </div>
         }
         <div class="card mb-3">
             <h5 class="card-header bg-secondary text-white" id="configurationcontainer">
@@ -91,6 +93,7 @@
     protected ThemeInfo? theme { get; set; }
 
     private bool admin = false;
+    private SiteConfiguration config = ConfigurationHelper.GetConfigurationData();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -98,6 +101,13 @@
         {
             var result = await session.GetAsync<bool>("admin");
             admin = (bool)result.Value;
+
+            if (Convert.ToBoolean(config.DisableGeneratedNamesLog) && !admin)
+            {
+                toastService.ShowWarning("The Instructions page is disabled in the site settings.");
+                NavigationManager.NavigateTo("/");
+            }
+
             StateHasChanged();
         }
     }

--- a/src/Shared/Components/NavMenu.razor
+++ b/src/Shared/Components/NavMenu.razor
@@ -36,11 +36,14 @@
                 </NavLink>
             </div>
         }
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="instructions">
-                <span class="oi oi-info" aria-hidden="true"></span> Instructions
-            </NavLink>
-        </div>
+        @if (!Convert.ToBoolean(config.DisableInstructions) || admin)
+        {
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="instructions">
+                    <span class="oi oi-info" aria-hidden="true"></span> Instructions
+                </NavLink>
+            </div>
+        }
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="configuration">
                 <span class="oi oi-cog" aria-hidden="true"></span> Configuration
@@ -56,11 +59,14 @@
                 <span class="oi oi-check" aria-hidden="true"></span> Generate
             </NavLink>
         </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="generatednameslog">
-                <span class="oi oi-list" aria-hidden="true"></span> Generated Names Log
-            </NavLink>
-        </div>
+        @if (!Convert.ToBoolean(config.DisableGeneratedNamesLog) || admin)
+        {
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="generatednameslog">
+                    <span class="oi oi-list" aria-hidden="true"></span> Generated Names Log
+                </NavLink>
+            </div>
+        }
 
         @if (GeneralHelper.IsNotNull(PageType))
         {
@@ -127,7 +133,7 @@
                 </div>
             }
 
-            @if ((PageType.ToString() == "AzureNamingTool.Pages.Index") && (connected))
+            @if ((PageType.ToString() == "AzureNamingTool.Pages.Index") && (connected) && !Convert.ToBoolean(config.DisableNews))
             {
                 <hr />
                 <div class="nav-item px-3">
@@ -162,6 +168,7 @@
     private string NavMenuCssClass => collapseNavMenu ? "collapse" : String.Empty;
     private bool newsenabled = false;
     private bool connected = true;
+    private SiteConfiguration config = ConfigurationHelper.GetConfigurationData();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {


### PR DESCRIPTION
Hi, I would like to introduce some more site settings:

- `DisableNews` -> Disable the news section for all users completely
- `DisableInstructions` -> Remove the "Instructions" page for non-admin users
- `DisableGeneratedNamesLog` -> Remove the "Generated Names Log" for non-admin users

I hope you find this useful and will merge it into the next release.