### PR TITLE
Update Devices/IotHubs/certificates resource type

### DIFF
--- a/src/repository/resourcetypes.json
+++ b/src/repository/resourcetypes.json
@@ -2808,7 +2808,7 @@
     "invalidCharactersStart": "",
     "invalidCharactersEnd": "",
     "invalidCharactersConsecutive": "",
-    "regx": "^[a-zA-Z0-9_-\\.]{1,64}$",
+    "Regx": "^[a-zA-Z0-9_\\.-]{1,64}$",
     "staticValues": ""
   },
   {


### PR DESCRIPTION
Existing Regex gives error in case you want to generate a name: Invalid pattern '^[a-zA-Z0-9_-\.]{1,64}$' at offset 15. [x-y] range in reverse order.