### PR TITLE
Bug/resource type logic/integration accounts certificates/maps

### DIFF
--- a/src/repository/resourcetypes.json
+++ b/src/repository/resourcetypes.json
@@ -3682,7 +3682,7 @@
     "invalidCharactersStart": "",
     "invalidCharactersEnd": "",
     "invalidCharactersConsecutive": "",
-    "regx": "^[a-zA-Z0-9_-\\.()]{1,80}$",
+    "regx": "^[a-zA-Z0-9_\\.()-]{1,80}$",
     "staticValues": ""
   },
   {
@@ -3701,7 +3701,7 @@
     "invalidCharactersStart": "",
     "invalidCharactersEnd": "",
     "invalidCharactersConsecutive": "",
-    "regx": "^[a-zA-Z0-9_-\\.()]{1,80}$",
+    "regx": "^[a-zA-Z0-9_\\.()-]{1,80}$",
     "staticValues": ""
   },
   {


### PR DESCRIPTION
Existing regx for 
"Resource": "Logic/integrationAccounts/maps",
"Resource": "Logic/integrationAccounts/certificates",

are generating errors:
Invalid pattern '^[a-zA-Z0-9_-\.()]{1,80}$' at offset 15. [x-y] range in reverse order.